### PR TITLE
replace submodule by system link & fix import wavedata errors

### DIFF
--- a/avod/core/format_checker.py
+++ b/avod/core/format_checker.py
@@ -48,6 +48,7 @@ The box_4c format is the following
 import numpy as np
 import tensorflow as tf
 
+import os, sys
 from wavedata.tools.obj_detection import obj_utils
 
 

--- a/scripts/install/build_integral_image_lib.bash
+++ b/scripts/install/build_integral_image_lib.bash
@@ -3,7 +3,7 @@ set -e # exit on first error
 
 build_integral_image_lib()
 {
-    cd wavedata/wavedata/tools/core/lib
+    cd wavedata/tools/core/lib
     cmake src
     make
 }

--- a/scripts/preprocessing/gen_mini_batches.py
+++ b/scripts/preprocessing/gen_mini_batches.py
@@ -1,5 +1,14 @@
 import os
 
+import sys
+cur_dir = os.path.dirname(__file__)
+avod_dir = os.path.abspath(os.path.join(cur_dir, '../..'))
+sys.path.append(avod_dir)
+#sys.path.append(os.path.abspath(os.path.join(avod_dir, 'avod')))
+sys.path.append(os.path.abspath(os.path.join(avod_dir, 'wavedata')))
+#sys.path.append(os.path.abspath(os.path.join(avod_dir, 'wavedata/wavedata')))
+print(sys.path)
+
 import numpy as np
 
 import avod


### PR DESCRIPTION
Given that AVOD is in $ROOT_DIR/avod,
Wavedata is cloned in $ROOT_DIR/wavedata

The syslink does "wavedata -> ../wavedata/wavedata" to find all relevant python scripts.